### PR TITLE
fix(user): change arrow function to regular function

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -22,7 +22,7 @@ module.exports = {
       defaultsTo: false
     },
 
-    toJSON: () => {
+    toJSON: function() {
       var values = this.toObject();
 
       delete values.password;


### PR DESCRIPTION
Fixes `this.toObject is not a function` error when calling `toJSON`.
